### PR TITLE
Enhancements to "derived updates" and body mesh

### DIFF
--- a/neuclease/clio/api.py
+++ b/neuclease/clio/api.py
@@ -61,3 +61,10 @@ def fetch_users(*, base=None, session=None):
     r = session.get(f"{base}/v2/users")
     r.raise_for_status()
     return r.json()
+
+
+@clio_api_wrapper
+def post_refresh_caches(base, session=None):
+    r = session.post(f"{base}/v2/refresh-caches")
+    r.raise_for_status()
+    return r.json()

--- a/neuclease/dvid/annotation.py
+++ b/neuclease/dvid/annotation.py
@@ -2627,3 +2627,8 @@ def example_ingest(server, uuid, tbar_and_psd_pickle_path):
     post_reload(server, uuid, 'synapses')
 
     print("Done.  Reload initiated.")
+
+    # Once that's done, initialize a labelsz instance
+    create_instance(server, uuid, 'labelsz', 'labelsz')
+    post_sync(server, uuid, 'labelsz', ['synapses'])
+    post_reload(server, uuid, 'labelsz')

--- a/neuclease/dvid/annotation.py
+++ b/neuclease/dvid/annotation.py
@@ -2403,9 +2403,14 @@ def partner_table_to_synapse_table(partner_df):
 
 
 def points_to_full_partner_table(point_df, partner_df):
+    """
+    Add columns from the point table to the partner table,
+    while simultaneously dropping any rows from the partner table
+    that don't have a corresponding row in the point table.
+    """
     assert point_df.index.name == 'point_id'
-    partner_df = partner_df.merge(point_df.rename_axis('pre_id'), 'left', on='pre_id')
-    partner_df = partner_df.merge(point_df.rename_axis('post_id'), 'left', on='post_id', suffixes=['_pre', '_post'])
+    partner_df = partner_df.merge(point_df.rename_axis('pre_id'), 'inner', on='pre_id')
+    partner_df = partner_df.merge(point_df.rename_axis('post_id'), 'inner', on='post_id', suffixes=['_pre', '_post'])
     return partner_df
 
 

--- a/neuclease/dvid/labelmap/_labelmap.py
+++ b/neuclease/dvid/labelmap/_labelmap.py
@@ -28,7 +28,7 @@ from ...util import (Timer, round_box, extract_subvol, DEFAULT_TIMESTAMP, tqdm_p
 
 from .. import dvid_api_wrapper, fetch_generic_json, fetch_repo_info, fetch_branch_nodes
 from ..server import fetch_server_info
-from ..repo import create_voxel_instance, fetch_repo_dag, is_locked, resolve_ref, expand_uuid, find_repo_root, resolve_ref_range, find_parent
+from ..repo import create_voxel_instance, fetch_repo_dag, is_locked, resolve_ref, find_repo_root, resolve_ref_range, find_parent
 from ..kafka import read_kafka_messages, kafka_msgs_to_df
 from ..rle import parse_rle_response, runlength_decode_from_ranges_to_mask, rle_ranges_box, construct_rle_payload_from_ranges, split_ranges_for_grid
 
@@ -88,8 +88,7 @@ def fetch_maxlabel(server, uuid, instance, *, session=None, dag=None):
         if ex.response is None or 'No maximum label' not in ex.response.content.decode('utf-8'):
             raise
 
-        uuid = resolve_ref(server, uuid)
-        uuid = expand_uuid(server, uuid)
+        uuid = resolve_ref(server, uuid, expand=True)
 
         # Oops, Issue 284
         # Search upwards in the DAG for a uuid with a valid max label

--- a/neuclease/dvid/labelmap/_labelmap.py
+++ b/neuclease/dvid/labelmap/_labelmap.py
@@ -947,34 +947,16 @@ def fetch_bodies_for_many_points(server, uuid, seg_instance, point_df, mutations
     assert not threads or not processes, "Choose either threads or processes (not both)"
     dvid_seg = (server, uuid, seg_instance)
 
-    if 'sv' not in point_df.columns:
+    if 'sv' in point_df.columns:
+        _update_supervoxels_for_mutated_bodies(server, uuid, seg_instance, mutations, point_df, threads, processes)
+    else:
         # Fetch supervoxel under all coordinates
         coords = point_df[[*'zyx']].values
-        point_df['sv'] = fetch_labels_batched(*dvid_seg, coords, supervoxels=True,
-                                              batch_size=batch_size, threads=threads, processes=processes)
-    else:
-        # Only update the supervoxel IDs for coordinates which reside on a supervoxel which
-        # was somehow involved in a split (as either parent or child).
-        # For those points, there's no guarantee that the supervoxel in the given table
-        # is in-sync with the given UUID, so we must check.
-        if mutations is None:
-            # We fetch the  mutations for the entire DAG (even other branches).
-            # That way, we don't care at all which UUID was used to produce the
-            # cached 'sv' column of the input table.
-            mutations = fetch_mutations(*dvid_seg, dag_filter=None)
+        point_df['sv'] = fetch_labels_batched(
+            *dvid_seg, coords, supervoxels=True,
+            batch_size=batch_size, threads=threads, processes=processes
+        )
 
-        if len(mutations) == 0:
-            msg = (f"Mutation log for instance '{seg_instance}' is empty for uuid '{uuid}' and its ancestors. "
-                   "If the mutation log is incorrectly missing and the given mapping is not in-sync with the "
-                   "given UUID, then the results of fetch_bodies_for_many_points() will be incorrect!")
-            logger.warning(msg)
-        else:
-            new, changed, deleted, new_svs, deleted_svs = compute_affected_bodies(mutations)
-            out_of_date = point_df.query('sv in @deleted_svs or sv in @new_svs').index
-            if len(out_of_date) > 0:
-                ood_coords = point_df.loc[out_of_date, [*'zyx']].values
-                point_df.loc[out_of_date, 'sv'] = fetch_labels_batched(
-                    *dvid_seg, ood_coords, supervoxels=True, batch_size=5_000, threads=threads, processes=processes)
     #
     # Now map from sv -> body
     #
@@ -1002,6 +984,46 @@ def fetch_bodies_for_many_points(server, uuid, seg_instance, point_df, mutations
     else:
         mapper = LabelMapper(*mapping.T)
         point_df['body'] = mapper.apply(point_df['sv'].values, True)
+
+
+def _update_supervoxels_for_mutated_bodies(server, uuid, seg_instance, mutations, point_df, threads, processes):
+    """
+    Helper for fetch_bodies_for_many_points()
+    """
+    dvid_seg = (server, uuid, seg_instance)
+
+    # Only update the supervoxel IDs for coordinates which reside on a supervoxel which
+    # was somehow involved in a split (as either parent or child).
+    # For those points, there's no guarantee that the supervoxel in the given table
+    # is in-sync with the given UUID, so we must check.
+
+    if mutations is None:
+        # We fetch the  mutations for the entire DAG (even other branches).
+        # That way, we don't care at all which UUID was used to produce the
+        # cached 'sv' column of the input table.
+        mutations = fetch_mutations(*dvid_seg, dag_filter=None)
+
+    if len(mutations) == 0:
+        logger.warning(
+            f"Mutation log for instance '{seg_instance}' is empty for uuid '{uuid}' and its ancestors. "
+            "If the mutation log is incorrectly missing and the given mapping is not in-sync with the "
+            "given UUID, then the results of fetch_bodies_for_many_points() will be incorrect!"
+        )
+        return
+
+    _new_bodies, _changed_bodies, _deleted_bodies, new_svs, deleted_svs = compute_affected_bodies(mutations)
+    out_of_date = point_df.query('sv in @deleted_svs or sv in @new_svs').index
+    if len(out_of_date) == 0:
+        return
+
+    ood_coords = point_df.loc[out_of_date, [*'zyx']].values
+    ood_svs = fetch_labels_batched(*dvid_seg, ood_coords, supervoxels=True, batch_size=5_000, threads=threads, processes=processes)
+
+    # pandas will complain if the dtypes don't match.
+    if ood_svs.dtype != point_df['sv'].dtype and ood_svs.max() > np.iinfo(point_df['sv'].dtype).max:
+        point_df['sv'] = point_df['sv'].astype(np.uint64)
+
+    point_df.loc[out_of_date, 'sv'] = ood_svs.astype(point_df['sv'].dtype)
 
 
 @dvid_api_wrapper
@@ -3916,7 +3938,7 @@ def _wait_for_split_done(server, uuid, instance, parent_sv, child_sv, indent=0, 
 
     (We can't check for the presence of the child ID because at low-res scales,
     the child ID isn't guaranteed to exist in the voxels at all, due to downsampling
-    effects. But we know the parent MUST NOT be absent.)
+    effects. But we know the parent MUST NOT be present.)
     """
     svc = fetch_sparsevol_coarse(server, uuid, instance, child_sv, supervoxels=True, format='coords')
 

--- a/neuclease/dvid/repo.py
+++ b/neuclease/dvid/repo.py
@@ -804,7 +804,7 @@ def find_parent(server, uuids, dag=None):
         dag = fetch_repo_dag(server, first_uuid)
 
     def _parent(uuid):
-        uuid = expand_uuid(server, uuid)
+        uuid = resolve_ref(server, uuid, expand=True)
         try:
             return next(dag.predecessors(uuid))
         except StopIteration:
@@ -993,7 +993,7 @@ def is_locked(server, uuid, *, session=None):
     is locked (via fetching the repo info).
     """
     repo_info = fetch_repo_info(server, uuid, session=session)
-    uuid = expand_uuid(server, uuid, repo_info=repo_info, session=session)
+    uuid = resolve_ref(server, uuid, expand=True, session=session)
     return repo_info['DAG']['Nodes'][uuid]['Locked']
 
 

--- a/neuclease/misc/bodymesh.py
+++ b/neuclease/misc/bodymesh.py
@@ -382,7 +382,7 @@ def create_supervoxel_mesh(server, uuid, seg_instance, sv, smoothing=3, decimati
     mesh.laplacian_smooth(smoothing)
 
     decimation = min(decimation_s0 * (4**SV_MESH_SCALE), 1.0)
-    mesh.simplify_openmesh(decimation)
+    mesh.simplify(decimation)
     return mesh
 
 
@@ -417,7 +417,7 @@ def update_body_mesh_from_supervoxels(server, uuid, seg_instance, body, body_mes
     logger.info(f"Original mesh has {orig_vertices} vertices and {len(mesh.faces)} faces ({mesh_mb:.1f} MB)")
 
     with Timer(f"Decimating at {decimation}", logger) as dec_timer:
-        mesh.simplify_openmesh(decimation)
+        mesh.simplify(decimation)
 
     mesh_mb = mesh.uncompressed_size() / 1e6
     logger.info(f"Final mesh has {len(mesh.vertices_zyx)} vertices and {len(mesh.faces)} faces ({mesh_mb:.1f} MB)")
@@ -662,7 +662,7 @@ def _generate_body_mesh_from_chunks(server, uuid, seg_instance, body, chunk_df, 
     decimation_seconds = 0.0
     if decimation <= 1.0:
         with Timer(f"Decimating body mesh with {decimation}", logger) as dec_timer:
-            body_mesh.simplify_openmesh(decimation)
+            body_mesh.simplify(decimation)
         decimation_seconds = dec_timer.seconds
 
     mesh_bytes = body_mesh.serialize(fmt='ngmesh')
@@ -758,7 +758,7 @@ def mesh_for_chunk(server, uuid, seg_instance, body, lastmod, chunk_config, qual
     decimation = min(decimation_s0 * 4**scale, 1.0)
 
     mesh.laplacian_smooth(smoothing)
-    mesh.simplify_openmesh(decimation)
+    mesh.simplify(decimation)
     if store:
         key = CHUNK_KEY_FMT.format(
             config_name=chunk_config['config-name'],

--- a/neuclease/misc/derived_updates.py
+++ b/neuclease/misc/derived_updates.py
@@ -46,8 +46,8 @@ SegmentationDvidInstanceSchema = {
                 "update script is run, starting at the root repo uuid.\n"
                 "Use this only if you know what you're doing! Once you use this setting, earlier "
                 "UUIDs will never be processed, even in subsequent calls to the update script.\n",
-            "type": "string",
-            "default": ""
+            "default": "",
+            "type": ["string", "null"]
         },
         "uuid": {
             "description": "version node from dvid for which the derived data will be brought in sync with the segmentation",

--- a/neuclease/misc/derived_updates.py
+++ b/neuclease/misc/derived_updates.py
@@ -374,6 +374,7 @@ def update_skeleton(dvid_server, uuid, seg_instance, body, mutid, neutu_executab
                     return
 
     cmd = f'{neutu_executable} --command --skeletonize --bodyid {body} "{dvid_server}?uuid={uuid}&segmentation={seg_instance}&label_zoom={scale}"'
+    logger.info(cmd)
     subprocess.run(cmd, shell=True, check=True)
 
 
@@ -390,7 +391,7 @@ def update_annotations(dvid_server, uuid, seg_instance, ignore_before_uuid=None)
         # (DVID doesn't complain.)
         delete_key(dvid_server, uuid, f"{seg_instance}_annotations", body)
 
-    store_update_receipt(*dvid_seg, "annoations", last_mutid)
+    store_update_receipt(*dvid_seg, "annotations", last_mutid)
 
 
 if __name__ == "__main__":

--- a/neuclease/misc/derived_updates.py
+++ b/neuclease/misc/derived_updates.py
@@ -270,7 +270,7 @@ def mutated_bodies_since_previous_update(dvid_server, uuid, seg_instance, derive
             updated_uuid = ignore_before_uuid
 
     recent_muts = fetch_mutations(dvid_server, f"[{updated_uuid}, {uuid}]", seg_instance)
-    recent_muts = recent_muts.query('mutid >= @updated_mutid')
+    recent_muts = recent_muts.query('mutid > @updated_mutid')
     if len(recent_muts) == 0:
         last_mutid = int(updated_mutid)
     else:

--- a/neuclease/misc/derived_updates.py
+++ b/neuclease/misc/derived_updates.py
@@ -379,7 +379,9 @@ def update_skeleton(dvid_server, uuid, seg_instance, body, mutid, neutu_executab
                 if swc_mutid >= mutid:
                     return
 
-    cmd = f'{neutu_executable} --command --skeletonize --bodyid {body} "{dvid_server}?uuid={uuid}&segmentation={seg_instance}&label_zoom={scale}"'
+    # We use --force here because we have already decided to regenerate the skeleton,
+    # so we don't want NeuTu to second-guess our decision.
+    cmd = f'{neutu_executable} --command --skeletonize --force --bodyid {body} "{dvid_server}?uuid={uuid}&segmentation={seg_instance}&label_zoom={scale}"'
     logger.info(cmd)
     subprocess.run(cmd, shell=True, check=True)
 

--- a/neuclease/misc/derived_updates.py
+++ b/neuclease/misc/derived_updates.py
@@ -181,8 +181,10 @@ def main():
     if 'skeletons' in cfg['update-derived-types']:
         update_skeletons(
             *dvid_seg,
+            cfg['skeletons']['neutu-executable'],
+            cfg['force-update'],
             cfg['skeletons']['scale'],
-            cfg['force-update']
+            cfg['dvid']['ignore-mutations-before-uuid']
         )
 
     if 'annotations' in cfg['update-derived-types']:
@@ -316,7 +318,7 @@ def update_body_meshes(dvid_server, uuid, seg_instance, body_mesh_config, chunk_
     store_update_receipt(*dvid_seg, "meshes", last_mutid)
 
 
-def update_skeletons(dvid_server, uuid, seg_instance, force, scale=5, ignore_before_uuid=None):
+def update_skeletons(dvid_server, uuid, seg_instance, neutu_executable, force, scale=5, ignore_before_uuid=None):
     dvid_seg = (dvid_server, uuid, seg_instance)
     prev_update, affected, last_mutid = mutated_bodies_since_previous_update(*dvid_seg, "skeletons", ignore_before_uuid)
 
@@ -345,7 +347,7 @@ def update_skeletons(dvid_server, uuid, seg_instance, force, scale=5, ignore_bef
             logger.info(f"Failed to fetch lastmod for body {body}")
             failed_bodies.append(body)
         else:
-            update_skeleton(*dvid_seg, body, mutid, force, scale)
+            update_skeleton(*dvid_seg, body, mutid, neutu_executable, force, scale)
 
     if not failed_bodies:
         store_update_receipt(*dvid_seg, "skeletons", last_mutid)

--- a/neuclease/misc/derived_updates.py
+++ b/neuclease/misc/derived_updates.py
@@ -227,6 +227,7 @@ def init_logging(config_path, logfile, stdout_logging=False):
 
 
 def mutated_bodies_since_previous_update(dvid_server, uuid, seg_instance, derived_type, ignore_before_uuid=None):
+    keys = []
     if "derived-data-checkpoints" in fetch_repo_instances(dvid_server, uuid):
         keys = fetch_keyrange(
             dvid_server,
@@ -235,6 +236,8 @@ def mutated_bodies_since_previous_update(dvid_server, uuid, seg_instance, derive
             f"{seg_instance}-{derived_type}-",
             f"{seg_instance}-{derived_type}-a"
         )
+
+    if keys:
         prev_update = fetch_key(dvid_server, uuid, "derived-data-checkpoints", max(keys))
     else:
         prev_update = {

--- a/neuclease/tests/test_segmentation.py
+++ b/neuclease/tests/test_segmentation.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 
 from dvidutils import LabelMapper
-from neuclease.util import mask_for_labels, apply_mask_for_labels, contingency_table, split_disconnected_bodies
+from neuclease.util import mask_for_labels, apply_mask_for_labels, contingency_table, split_disconnected_bodies, fill_holes_in_mask
 
 def test_mask_for_labels():
     volume = [[0,2,3], [4,5,0]]
@@ -113,6 +113,44 @@ def test_split_disconnected_bodies():
     mapper = LabelMapper(np.fromiter(mapping.keys(), np.uint64), np.fromiter(mapping.values(), np.uint64))
     assert (mapper.apply(split, True) == orig).all(), \
         "Applying mapping to the relabeled image did not recreate the original image."
+
+
+def test_fill_holes_in_mask():
+    _ = 0
+    X = 1
+    mask = np.array([
+        [_, _, _, _, _, X, _, _, _, _, _],
+        [_, _, X, X, X, X, X, X, X, _, _],
+        [_, X, X, X, X, X, X, X, X, X, _],
+        [_, X, X, _, _, _, _, _, X, X, _],
+        [_, X, X, X, X, X, X, X, X, X, _],
+        [_, X, X, _, _, _, _, _, X, X, _],
+        [_, X, X, X, X, X, X, X, X, X, _],
+        [_, X, X, _, _, _, _, _, X, X, _],
+        [_, X, X, X, X, X, X, X, X, X, _],
+        [_, _, X, X, X, X, X, X, X, _, _],
+        [_, _, _, _, _, X, _, _, _, _, _]
+    ])
+    expected = np.array([
+        [_, _, _, _, _, X, _, _, _, _, _],
+        [_, _, X, X, X, X, X, X, X, _, _],
+        [_, X, X, X, X, X, X, X, X, X, _],
+        [_, X, X, X, X, X, X, X, X, X, _],
+        [_, X, X, X, X, X, X, X, X, X, _],
+        [_, X, X, X, X, X, X, X, X, X, _],
+        [_, X, X, X, X, X, X, X, X, X, _],
+        [_, X, X, X, X, X, X, X, X, X, _],
+        [_, X, X, X, X, X, X, X, X, X, _],
+        [_, _, X, X, X, X, X, X, X, _, _],
+        [_, _, _, _, _, X, _, _, _, _, _]
+    ])
+
+    filled = fill_holes_in_mask(mask)
+    assert (filled == expected).all()
+
+    r = fill_holes_in_mask(mask, inplace=True)
+    assert r is None
+    assert (mask == expected).all()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `derived-updates` tool is used in our jenkins service to synchronize skeletons, meshes, and annotations in response to changes in the underlying segmentation.

This PR irons out some issues with it.

- When updating many skeletons, efficiently determine the set of skeleton keys to delete.
- Iron out edge cases in the bookkeeping logic for update receipts.
- Log obsolete annotations to disk before deleting them.
- Support skeletonizing on a locked DVID node (using the admintoken)
- Support `:master` syntax instead of requiring explicit UUID.

The code for generating body meshes (from chunk meshes) received some updates:

- It now optionally performs morphological closing on the segmentation mask before generating the mesh, which vastly reduces the vertex count for noisy regions like cell bodies.
- Since `vol2mesh` was recently updated to use `pyfqmr` for mesh simplification (sorry, no PR), our chunk/body mesh code now uses that simplification method instead of the one based on OpenMesh.

And there are a few unrelated changes in this PR:

- Fixed a bug in a crucial dataframe manipulation during synapse ingestion when the "points table" and "partner table" don't refer to the same point set.
- A few other minor things.