### PR TITLE
two small `neuclease` fixes

### DIFF
--- a/neuclease/focused/ng_focused.py
+++ b/neuclease/focused/ng_focused.py
@@ -57,7 +57,7 @@ ASSIGNMENT_EXAMPLE = """\
 """
 
 
-def edges_to_assignment(df, gray_source, seg_source, sv_as_body=False, output_path=None, shuffle=False, description="", task_type='body merge', result_labels=None, dvid_src=None):
+def edges_to_assignment(df, gray_source, seg_source, sv_as_body=False, output_path=None, shuffle=False, description="", task_type='body merge', result_labels=None, results_instance=None, dvid_src=None):
     if isinstance(df, str):
         df = pd.read_csv(df)
 
@@ -170,6 +170,8 @@ def edges_to_assignment(df, gray_source, seg_source, sv_as_body=False, output_pa
         assignment["task set description"] = description
     if result_labels:
         assignment["result labels"] = result_labels
+    if results_instance:
+        assignment["results instance"] = results_instance
     assignment['task list'] = tasks
 
     assignment = convert_nans(assignment)
@@ -179,7 +181,7 @@ def edges_to_assignment(df, gray_source, seg_source, sv_as_body=False, output_pa
     return assignment
 
 
-def edges_to_assignments(df, gray_source, seg_source, sv_as_body=False, batch_size=100, output_path=None, *, shuffle=False, description="", task_type='body merge', result_labels=None, dvid_src=None):
+def edges_to_assignments(df, gray_source, seg_source, sv_as_body=False, batch_size=100, output_path=None, *, shuffle=False, description="", task_type='body merge', result_labels=None, results_instance=None, dvid_src=None):
     if isinstance(df, str):
         df = pd.read_csv(df)
     assert isinstance(df, pd.DataFrame)
@@ -204,7 +206,7 @@ def edges_to_assignments(df, gray_source, seg_source, sv_as_body=False, batch_si
         else:
             batch_path = None
 
-        a = edges_to_assignment(batch_df, gray_source, seg_source, sv_as_body, batch_path, description=description, task_type=task_type, result_labels=result_labels, dvid_src=dvid_src)
+        a = edges_to_assignment(batch_df, gray_source, seg_source, sv_as_body, batch_path, description=description, task_type=task_type, result_labels=result_labels, results_instance=results_instance, dvid_src=dvid_src)
         assignments.append(a)
 
 

--- a/neuclease/misc/supervoxel_meshes_for_body.py
+++ b/neuclease/misc/supervoxel_meshes_for_body.py
@@ -131,7 +131,7 @@ def supervoxel_meshes_for_body(server, uuid, instance, body, scale=2,
     )
     meshes = compute_parallel(func, sv_sizes.index, processes=processes)
     sv_meshes = dict(zip(sv_sizes.index, meshes))
-    sv_meshes = {f'{sv}.drc': mesh for sv, mesh in sv_meshes.items()}
+    sv_meshes = {f'{sv}.{format}': mesh for sv, mesh in sv_meshes.items()}
 
     if upload:
         post_load(server, uuid, f'{instance}_sv_meshes', sv_meshes)


### PR DESCRIPTION
Two quick patches:
- First, bug fix: `supervoxel_meshes_for_body()` accepts a `format` parameter but had the file extension hard-coded to `.drc`.
- Second, added `results_instance` parameter to `edges_to_assignments()` as it is supported by clio's focused protocol at least. It's up to the user to know if your protocol of interest can use it or not. If that's too loosey-goosey, I'm OK cutting that out.
