### PR TITLE
Recent development updates to supervoxel mesh generation, neuroglancer utilities, etc.

### DIFF
--- a/neuclease/dvid/keyvalue/_keyvalue.py
+++ b/neuclease/dvid/keyvalue/_keyvalue.py
@@ -614,7 +614,7 @@ def extend_list_value(server, uuid, instance, key, new_list, *, session=None):
         post_key(server, uuid, instance, key, json=new_list, session=session)
 
 
-# Copied from the following URL, but I inserted the empty status ("").
+# Copied from the following URL, with additions (e.g. the "" (empty) status).
 # http://emdata5.janelia.org:8400/api/node/b31220/neutu_config/key/body_status_v2
 DEFAULT_BODY_STATUS_CATEGORIES = [
     'Unimportant',
@@ -630,6 +630,7 @@ DEFAULT_BODY_STATUS_CATEGORIES = [
     '0.5assign',
     'Anchor',
     'Cleaved Anchor',
+    'Will be merged',
     'Sensory Anchor',
     'Cervical Anchor',
     'Soma Anchor',

--- a/neuclease/misc/bodymesh.py
+++ b/neuclease/misc/bodymesh.py
@@ -401,7 +401,7 @@ def create_supervoxel_mesh(server, uuid, seg_instance, sv, smoothing=3, decimati
     """
     with resource_mgr.access_context(server, True, 1, 0):
         try:
-            rng = fetch_sparsevol(server, uuid, seg_instance, sv, scale=SV_MESH_SCALE, format='ranges')
+            rng = fetch_sparsevol(server, uuid, seg_instance, sv, scale=SV_MESH_SCALE, supervoxels=True, format='ranges')
         except HTTPError as ex:
             # If the supervoxel has been split already, then we can't generate a mesh for it.
             if ex.response.status_code == 404:

--- a/neuclease/misc/cosine_autoproof.py
+++ b/neuclease/misc/cosine_autoproof.py
@@ -5,11 +5,10 @@ import numpy as np
 import pandas as pd
 from functools import partial
 
-from tqdm.auto import tqdm, trange
 from sklearn.metrics.pairwise import cosine_similarity
 
 from neuprint import Client, fetch_neurons, fetch_adjacencies, fetch_mean_synapses, NeuronCriteria as NC, NotNull
-from neuclease.util import compute_parallel
+from neuclease.util import compute_parallel, tqdm_proxy
 from neuclease.misc.neuroglancer import parse_nglink, layer_dict, segment_properties_json, upload_to_bucket, upload_ngstate
 
 
@@ -27,6 +26,9 @@ def main():
     parser.add_argument('output_links_csv', type=str, nargs='?')
 
     args = parser.parse_args()
+
+    from neuclease import configure_default_logging
+    configure_default_logging()
 
     c = Client(args.neuprint_server, args.neuprint_dataset, progress=False)
     threshold_strength = args.ignore_connections_below
@@ -142,7 +144,7 @@ def _target_type_strengths(orphan_upstream_types, orphan_downstream_types, orpha
 
 def _improvements(orphan, orphan_type_strengths, target_type_strengths, threshold_strength, show_progress):
     improvements = []
-    progress = tqdm(total=len(target_type_strengths), leave=False, disable=not show_progress)
+    progress = tqdm_proxy(total=len(target_type_strengths), leave=False, disable=not show_progress)
     with progress:
         for t, ts in target_type_strengths.groupby('type'):
             if len(ts) == 1:

--- a/neuclease/misc/cosine_autoproof.py
+++ b/neuclease/misc/cosine_autoproof.py
@@ -34,7 +34,13 @@ def main():
 
     c = Client(args.neuprint_server, args.neuprint_dataset, progress=False)
     threshold_strength = args.ignore_connections_below
-    orphan_df = pd.read_csv(args.orphans_csv)
+
+    if not args.orphans_csv.endswith('.csv') and str.isalnum(args.orphans_csv):
+        orphan_df = pd.DataFrame({'orphan': [int(args.orphans_csv)]})
+        args.orphans_csv = args.orphans_csv + '.csv'
+    else:
+        orphan_df = pd.read_csv(args.orphans_csv)
+
     orphans_df = orphan_df.rename(columns={'body': 'orphan', 'bodyId': 'orphan'})
     orphans = orphans_df['orphan'].tolist()
 

--- a/neuclease/misc/cosine_autoproof.py
+++ b/neuclease/misc/cosine_autoproof.py
@@ -214,6 +214,9 @@ def _neuroglancer_link(orphan, max_target_types, template_link, target_df, bucke
     state = parse_nglink(template_link)
     state['title'] = f"Orphan {orphan}: Proposed targets"
     state["position"] = mean_position
+    state["layerListPanel"] = {
+        "visible": True
+    }
     
     layers = layer_dict(state)
     if 'orphan' not in layers or 'targets' not in layers:
@@ -237,6 +240,10 @@ def _neuroglancer_link(orphan, max_target_types, template_link, target_df, bucke
     orphan_layer['name'] = f"orphan-{orphan}"
     orphan_layer['segments'] = [str(orphan)]
     orphan_layer['segmentQuery'] = str(orphan)
+
+    layers['orphan-synapses']["linkedSegmentationLayer"] = {
+        "segments": orphan_layer['name']
+      }
 
     targets_layer = layers['targets']
     targets_position = list(layers.keys()).index('targets')

--- a/neuclease/misc/cosine_autoproof.py
+++ b/neuclease/misc/cosine_autoproof.py
@@ -146,8 +146,8 @@ def _target_type_strengths(orphan, orphan_upstream_types, orphan_downstream_type
 
     bodies_downstream_of_upstream = bodies_downstream_of_upstream.query('bodyId != @orphan')
     bodies_upstream_of_downstream = bodies_upstream_of_downstream.query('bodyId != @orphan')
-    conn_upstream_of_downstream = conn_upstream_of_downstream.query('bodyId_pre != @orphan and bodyId_post != @orphan')
-    conn_downstream_of_upstream = conn_downstream_of_upstream.query('bodyId_pre != @orphan and bodyId_post != @orphan')
+    conn_upstream_of_downstream = conn_upstream_of_downstream.query('bodyId_pre != @orphan and bodyId_post != @orphan').copy()
+    conn_downstream_of_upstream = conn_downstream_of_upstream.query('bodyId_pre != @orphan and bodyId_post != @orphan').copy()
 
     conn_downstream_of_upstream['type_pre'] = conn_downstream_of_upstream['bodyId_pre'].map(bodies_downstream_of_upstream.set_index('bodyId')['type'])
     conn_upstream_of_downstream['type_post'] = conn_upstream_of_downstream['bodyId_post'].map(bodies_upstream_of_downstream.set_index('bodyId')['type'])

--- a/neuclease/misc/cosine_autoproof.py
+++ b/neuclease/misc/cosine_autoproof.py
@@ -28,7 +28,7 @@ def main():
 
     args = parser.parse_args()
 
-    c = Client(args.neuprint_server, args.neuprint_dataset)
+    c = Client(args.neuprint_server, args.neuprint_dataset, progress=False)
     threshold_strength = args.ignore_connections_below
     orphans = pd.read_csv(args.orphans_csv)['body'].tolist()
 

--- a/neuclease/misc/cosine_autoproof.py
+++ b/neuclease/misc/cosine_autoproof.py
@@ -180,7 +180,7 @@ def _improvements(orphan, orphan_type_strengths, target_type_strengths, threshol
                 ))
                 progress.update(1)
 
-    columns = ['orphan', 'target', 'type', 'similar_body_connections', 'similar_type_connections', 'score']
+    columns = ['orphan', 'target', 'type', 'score', 'similar_body_connections', 'similar_type_connections']
     improvements = (
         pd.DataFrame(improvements, columns=columns)
         .sort_values(['similar_body_connections', 'similar_type_connections', 'score'], ascending=False)

--- a/neuclease/misc/neuroglancer/__init__.py
+++ b/neuclease/misc/neuroglancer/__init__.py
@@ -10,5 +10,5 @@ from .annotations.local import (
     extract_annotations, annotation_layer_json, point_annotation_layer_json
 )
 from .annotations.precomputed import write_precomputed_annotations
-from .segmentprops import segment_properties_json
+from .segmentprops import segment_properties_json, segment_properties_to_dataframe
 from .segmentcolors import hex_string_from_segment_id

--- a/neuclease/misc/neuroglancer/annotations/precomputed/precomputed.py
+++ b/neuclease/misc/neuroglancer/annotations/precomputed/precomputed.py
@@ -171,6 +171,11 @@ def write_precomputed_annotations(
             while (approximately) adhering to the target_chunk_limit at each level, then the
             extra annotations will be assigned to the last level.
 
+            Note:
+                Instead of specifying a valid limit here, you can disable subsampling in neuroglancer
+                by setting this to the special value of 0.  In our implementation, this is only valid
+                when num_spatial_levels=1.
+
         shuffle_before_assigning_spatial_levels:
             bool
             Whether to shuffle the annotations before assigning spatial levels.

--- a/neuclease/misc/neuroglancer/annotations/precomputed/precomputed.py
+++ b/neuclease/misc/neuroglancer/annotations/precomputed/precomputed.py
@@ -434,6 +434,12 @@ def _encode_geometries_and_properties(df, coord_space, annotation_type, property
         else:
             dtypes[p] = spec['type']
 
+    if any(dt == np.int8 for dt in dtypes.values()):
+        logger.warning(
+            "Old versions of neuroglancer don't support int8 properties, "
+            "so consider casting to uint8 or int16 if your annotations don't load."
+        )
+
     # Convert category columns to their integer equivalents
     for spec in property_specs:
         p = spec['id']

--- a/neuclease/misc/neuroglancer/annotations/precomputed/precomputed.py
+++ b/neuclease/misc/neuroglancer/annotations/precomputed/precomputed.py
@@ -57,7 +57,6 @@ def write_precomputed_annotations(
     Args:
         df:
             DataFrame or TableHandle.
-            If a TableHandle, the handle's reference will be unset before this function returns.
             The index of the DataFrame is used as the annotation ID, so it must be unique.
             The required columns depend on the annotation_type and the coordinate space.
             For example, assuming ``coord_space.names == ['x', 'y', 'z']``,
@@ -71,6 +70,10 @@ def write_precomputed_annotations(
 
             You may also provide additional columns to use as annotation properties, in which
             case their column names should be listed in the 'properties' argument. (See below.)
+
+            If you provide a TableHandle, the handle's reference will be unset before this
+            function returns, deleting your data if you didn't retain a reference to it yourself.
+            (If you do retain a reference, it defeats the point of using a TableHandle in the first place.)
 
         coord_space:
             CoordinateSpace or equivalent.

--- a/neuclease/misc/neuroglancer/annotations/util.py
+++ b/neuclease/misc/neuroglancer/annotations/util.py
@@ -140,10 +140,14 @@ def _proptype(s):
 
     if s.dtype == 'category':
         num_cats = len(s.dtype.categories)
-        for utype in (np.uint8, np.uint16, np.uint32):
-            if num_cats <= 1 + np.iinfo(utype).max:
-                return str(np.dtype(utype))
-        raise RuntimeError(f"Column {s.name} has too many categories")
+        if s.cat.codes.dtype == np.int8:
+            # Old versions of neuroglancer had a bug for int8 property types,
+            # so we store them as uint8.
+            # https://github.com/google/neuroglancer/pull/830
+            return 'uint8'
+
+        # Pandas already stores categorical codes with a minimal-width dtype
+        return str(np.dtype(s.cat.codes.dtype))
 
     if s.dtype != object:
         raise RuntimeError(f"Unsupported property dtype: {s.dtype} for column {s.name}")

--- a/neuclease/misc/neuroglancer/annotations/util.py
+++ b/neuclease/misc/neuroglancer/annotations/util.py
@@ -100,6 +100,9 @@ def annotation_property_specs(df, properties):
 
     for col in default_property_specs.keys():
         if col in df and df[col].dtype == "category":
+            if df[col].isnull().any():
+                raise ValueError(f"Column {col} can't be used for an enum property because it has null values")
+
             cats = df[col].cat.categories.tolist()
             default_property_specs[col]['enum_values'] = [*range(len(cats))]
             default_property_specs[col]['enum_labels'] = cats


### PR DESCRIPTION
- Important bug fix in the function that generates supervoxel meshes for our jenkins jobs (fetch the supervoxel sparsevol, not the body sparsevol for a supervoxel ID)
- New body status option: `Will be merged`, which I'm using in our `v0.9` branch of the male CNS to flag bodies which exist in that branch but were later merged in our main branch (and thus will be fixed in our next data release).
- minor updates to neuroglancer utilities:
    - For precomputed annotations, workaround/warning for a bug in neuroglancer that serialized `int8` properties incorrectly (I fixed it in https://github.com/google/neuroglancer/pull/830)
    - Better error handling for invalid categorical input
    - Explicit option for disabling neuroglancer subsampling for annotations
    - Expose `segment_properties_to_dataframe()` in the subpackage namespace
    - Added a reference WebGL shader for the neuroglancer random segment color algorithm, which can be pasted into annotation layer shaders to make annotation colors match the colors in a segmentation layer.  (Only works for uint32 segment IDs, and only if the user manually ensures that the hash seed matches the one in the segmentation layer.)
- Robustness and usability enhancements in the `cosine_autoproof` tool (which proposes orphan merges based on connectivity similarity to a set of targets)

---

cc @olbris @DocSavage @StephanPreibisch
