### PR TITLE
2026 08 improve tests

### DIFF
--- a/neuclease/cleave/merge_graph.py
+++ b/neuclease/cleave/merge_graph.py
@@ -48,6 +48,14 @@ def standardize_servername(server):
     protocol = m.group('protocol') or ''
     domain = m.group('domain') or ''
     port = m.group('port') or ''
+
+    if domain in ('localhost', '127.0.0.1', '::1'):
+        # getfqdn() performs a reverse DNS lookup, which for loopback addresses
+        # can return a bogus, non-resolvable name (e.g. '1.0.0.127.in-addr.arpa')
+        # depending on the local resolver configuration. Loopback addresses
+        # don't need canonicalization anyway, so just leave them as-is.
+        return f"{protocol}{domain}{port}"
+
     fqdn = getfqdn(domain)
     return f"{protocol}{fqdn}{port}"
 

--- a/neuclease/tests/test_merge_graph.py
+++ b/neuclease/tests/test_merge_graph.py
@@ -8,7 +8,8 @@ from libdvid import DVIDNodeService
 
 from neuclease.dvid import ( DvidInstanceInfo, post_key, post_branch, create_instance,
                              fetch_mutation_id, post_cleave, post_split_supervoxel, post_merge )
-from neuclease.cleave.merge_graph import LabelmapMergeGraph
+# note: I think these tests were written when the "local table" implementation was the only one...
+from neuclease.cleave.merge_graph import LabelmapMergeGraphLocalTable as LabelmapMergeGraph
 from neuclease.cleave.merge_table import load_merge_table, MAPPED_MERGE_TABLE_DTYPE
 
 ##


### PR DESCRIPTION
Contains two fixes that make the test runnable again.

(1) Fixed a class name that apparently changed; this allows the tests to be gathered and run. I made a guess identifying which subclass was the only class when the tests were written.

(2) Fixed a server check that prevented DVID server from starting for one set of tests. Claude worked this one out. 

